### PR TITLE
Feature/initial sync with huge files

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ message | oslc:message | xsd:string
 Finds the latest dcat:Dataset a sync point to ingest. Once done, it proceeds in delta-sync mode.
 See also [delta-producer-dump-file-publisher](https://github.com/lblod/delta-producer-dump-file-publisher).
 
+**LIMITATION:** The initial sync will only work with files with plain N3 triples.
+
 #### Delta-sync
 At regular intervals, the service will schedule a sync task. Execution of a task consists of the following steps:
 

--- a/lib/dump-file.js
+++ b/lib/dump-file.js
@@ -85,7 +85,6 @@ class DumpFile {
    * They are then dispatched to the database.
    */
   async parseAndDispatch(dispatch) {
-    const parser = new Parser();
     const ttlStream = fs.createReadStream(this.filePath);
 
     // Interface to read stream line by line
@@ -102,8 +101,10 @@ class DumpFile {
 
     for await (const line of rl) {
       linesToParse.push(line);
-      try {
-        const parsedQuad = parser.parse(linesToParse.toString())[0];
+
+      const parsedQuad = this.getParsedQuad(linesToParse, line)
+
+      if (parsedQuad) {
         linesToParse = [];
 
         storage.push(parsedQuad);
@@ -112,9 +113,44 @@ class DumpFile {
           await this.toTermObjectAndDispatch(storage, dispatch);
           storage = [];
         }
-      } catch (e) {
-        console.log('Parsing failed, expecting multi-line parsing. Waiting for next iteration.');
       }
+    }
+  }
+
+  /**
+   * Helper to get parsed quad from an array of lines. Parsing can fail in 2 cases :
+      - We have a multiline triple -> Next iteration(s) will solve the problem by themselves
+      - The ttl file is partially broken -> We wait for the next parsable triple and start back from there
+   *
+   * @param {Array} lines Array of lines to parse
+   * @param {string} currentLine Current line we're on
+   */
+  getParsedQuad(lines, currentLine) {
+      let parsedQuad = this.tryToParse(lines);
+
+      if (parsedQuad) {
+        return parsedQuad;
+      } else {
+        parsedQuad = this.tryToParse([currentLine]);
+
+        if (parsedQuad) {
+          console.log(`Previously stored lines are broken ttl. Starting again from line: "${currentLine}"`);
+          return parsedQuad;
+        } else {
+          // Either multiline triple or broken ttl, next iteration(s) will tell us.
+          return null;
+        }
+      }
+  }
+
+  // Helper that tries to parse an array of lines.
+  // Returns the parsed value if successful, null if the parsing failed
+  tryToParse(lines) {
+    const parser = new Parser();
+    try {
+      return parser.parse(lines.toString())[0]
+    } catch (e) {
+      return null;
     }
   }
 

--- a/lib/dump-file.js
+++ b/lib/dump-file.js
@@ -96,9 +96,7 @@ class DumpFile {
     let storage = [];
     let linesToParse = [];
 
-    let isLastLine = false;
-    ttlStream.on('end', () => { isLastLine = true });
-
+    // Store triples by batches
     for await (const line of rl) {
       linesToParse.push(line);
 
@@ -109,11 +107,17 @@ class DumpFile {
 
         storage.push(parsedQuad);
 
-        if (storage.length === BATCH_SIZE || isLastLine) {
+        if (storage.length === BATCH_SIZE) {
           await this.toTermObjectAndDispatch(storage, dispatch);
           storage = [];
         }
       }
+    }
+
+    // Store remaining triples
+    if (storage.length) {
+      await this.toTermObjectAndDispatch(storage, dispatch);
+      storage = [];
     }
   }
 

--- a/lib/dump-file.js
+++ b/lib/dump-file.js
@@ -83,6 +83,11 @@ class DumpFile {
    *        We will attach this line with the following one and try to parse it again.
    * Once the triples are parsed, they are stored in an array until it reaches a BATCH_SIZE or the end of the file.
    * They are then dispatched to the database.
+   *
+   * LIMITATION
+   * The parsing will only work on N3 triples. Prettified turtle will break. In our case, it's OK because we
+   * also handle the creation of the file we ingest, but in the future it might be useful to use a more robust parser,
+   * the difficulty being that we need to have control on the speed of the stream input.
    */
   async parseAndDispatch(dispatch) {
     const ttlStream = fs.createReadStream(this.filePath);

--- a/lib/dump-file.js
+++ b/lib/dump-file.js
@@ -1,4 +1,7 @@
+import * as muAuthSudo from '@lblod/mu-auth-sudo';
+import * as mu from 'mu';
 import fs from 'fs-extra';
+import readline from 'readline';
 import { sparqlEscapeString, sparqlEscapeUri } from 'mu';
 import { Parser } from 'n3';
 import fetcher from './fetcher';
@@ -9,11 +12,13 @@ import {
     SYNC_BASE_URL,
     SYNC_DATASET_ENDPOINT,
     SYNC_DATASET_SUBJECT,
-    SYNC_FILES_PATH
+    SYNC_FILES_PATH,
 } from '../config';
 
 const BASEPATH = path.join(SYNC_FILES_PATH, DUMPFILE_FOLDER);
 fs.ensureDirSync(BASEPATH);
+
+const BATCH_SIZE = 1000;
 
 class DumpFile {
   constructor(distributionData, data) {
@@ -46,18 +51,19 @@ class DumpFile {
     }
   }
 
-  async load() {
+  async loadAndDispatch(dispatch) {
     try {
+      console.log(`Downloading file at ${this.downloadUrl}`);
       await this.download();
+
       const stat = await fs.stat(this.filePath);
+
       if(stat.size > 0) {
-        const ttlStream = fs.createReadStream(this.filePath);
-        let triples = await this.toTermObjectArray(ttlStream); //Note this loads in full ttl in memory. this will certainly explode one day
-        console.log(`Successfully loaded file ${this.id} stored at ${this.filePath}`);
-        return triples;
+        await this.parseAndDispatch(dispatch)
+
+        console.log(`Successfully loaded and dispatched file ${this.id} stored at ${this.filePath}`);
       } else {
         console.error(`File ${this.filePath} is empty`);
-        return [];
       }
     }
     catch(error){
@@ -67,8 +73,67 @@ class DumpFile {
     }
   }
 
+  /**
+   * Helper that creates a stream from the file's location and process it line by line.
+   * The processing includes 3 steps:
+   *   1. Get the first line of the stream
+   *   2. Try to parse it with a ttl parser
+   *   3. If it succeeded, dispatch the parsed triple to the database
+   *      If it failed, it means the triple is spread accross multiple lines.
+   *        We will attach this line with the following one and try to parse it again.
+   * Once the triples are parsed, they are stored in an array until it reaches a BATCH_SIZE or the end of the file.
+   * They are then dispatched to the database.
+   */
+  async parseAndDispatch(dispatch) {
+    const parser = new Parser();
+    const ttlStream = fs.createReadStream(this.filePath);
+
+    // Interface to read stream line by line
+    const rl = readline.createInterface({
+      input: ttlStream,
+      crlfDelay: Infinity
+    });
+
+    let storage = [];
+    let linesToParse = [];
+
+    let isLastLine = false;
+    ttlStream.on('end', () => { isLastLine = true });
+
+    for await (const line of rl) {
+      linesToParse.push(line);
+      try {
+        const parsedQuad = parser.parse(linesToParse.toString())[0];
+        linesToParse = [];
+
+        storage.push(parsedQuad);
+
+        if (storage.length === BATCH_SIZE || isLastLine) {
+          await this.toTermObjectAndDispatch(storage, dispatch);
+          storage = [];
+        }
+      } catch (e) {
+        console.log('Parsing failed, expecting multi-line parsing. Waiting for next iteration.');
+      }
+    }
+  }
+
+  // Helper to convert parsed Quads to triple objects and dispatch them to the database
+  async toTermObjectAndDispatch(data, dispatch) {
+    const triples = data.map(triple => {
+      return {
+        graph: null,
+        subject: this.serializeN3Term(triple.subject),
+        predicate: this.serializeN3Term(triple.predicate),
+        object: this.serializeN3Term(triple.object)
+      };
+    });
+
+    await dispatch({ mu, muAuthSudo }, { termObjects: triples });
+  }
+
   serializeN3Term(rdfTerm) {
-    //Based on: https://github.com/kanselarij-vlaanderen/dcat-dataset-publication-service/blob/master/lib/ttl-helpers.js#L48
+    // Based on: https://github.com/kanselarij-vlaanderen/dcat-dataset-publication-service/blob/master/lib/ttl-helpers.js#L48
     const {termType, value, datatype, language} = rdfTerm;
     if (termType === 'NamedNode') {
       return sparqlEscapeUri(value);
@@ -89,38 +154,6 @@ class DumpFile {
       console.log(`Don't know how to escape type ${termType}. Will escape as a string.`);
       return sparqlEscapeString(value);
     }
-  }
-
-  //Helper function to parse TTL file.
-  async toTermObjectArray(data) {
-    const parser = new Parser();
-
-    const triples = [];
-
-    return new Promise((resolve, reject) => {
-
-      const quads = parser.parse(data, (error, quad) => {
-        if(error) {
-          reject(error);
-        } else if(quad) {
-          //TODO: check if this is still needed, but I remember there were subtle differences
-          try {
-            triples.push(
-              {
-                graph: null,
-                subject: this.serializeN3Term(quad.subject),
-                predicate: this.serializeN3Term(quad.predicate),
-                object: this.serializeN3Term(quad.object)
-              }
-            );
-          } catch(e){
-            reject(e);
-          }
-        } else {
-          resolve(triples);
-        }
-      });
-    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delta-consumer",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Customizable consumer service to synchronise data from a producer stack",
   "main": "app.js",
   "scripts": {

--- a/pipelines/initial-sync.js
+++ b/pipelines/initial-sync.js
@@ -1,5 +1,3 @@
-import * as muAuthSudo from '@lblod/mu-auth-sudo';
-import * as mu from 'mu';
 import {
     DISABLE_INITIAL_SYNC, INITIAL_SYNC_JOB_OPERATION,
     JOBS_GRAPH, JOB_CREATOR_URI, SERVICE_NAME
@@ -46,17 +44,15 @@ async function runInitialSync() {
   let task;
 
   try {
-
     // Note: they get status busy
     job = await createJob(JOBS_GRAPH, INITIAL_SYNC_JOB_OPERATION, JOB_CREATOR_URI, STATUS_BUSY);
-    task = await createTask(JOBS_GRAPH, job,"0", INITIAL_SYNC_TASK_OPERATION, STATUS_SCHEDULED);
+    task = await createTask(JOBS_GRAPH, job, "0", INITIAL_SYNC_TASK_OPERATION, STATUS_SCHEDULED);
 
     const dumpFile = await getLatestDumpFile();
 
     if (dumpFile) {
       await updateStatus(task, STATUS_BUSY);
-      const termObjects = await dumpFile.load();
-      await initialSyncDispatching.dispatch({ mu, muAuthSudo }, { termObjects });
+      await dumpFile.loadAndDispatch(initialSyncDispatching.dispatch);
       await updateStatus(task, STATUS_SUCCESS);
     } else {
       console.log(`No dump file to consume. Is the producing stack ready?`);


### PR DESCRIPTION
# Context

Now that our dataset is getting bigger, the initial syncs start to suffer as well. `JavaScript heap out of memory` error are appearing.

This PR is an update to avoid having to load the entire file content into memory to be able to process it. Instead, we process it by batches and immediately store the batches in the DB before moving on to the next one.

# Attention points

I was especially careful because if means that I now read the ttl files line by line, which can be an issue in case of triples speading over multiple lines or in case of broken ttl pieces. I tried to cover all the edge cases, but if you think at others please comment here.

**To test :** the dump file that made it crash is the decisions from the harvester. I tested by making an initial sync between Centrale Vindplaats and the Harvester, via the `besluiten-consumer` service. I took about 4h to complete on my local machine.

-----

**Note to myself** : tag before resolving conflicts and merging to master