### PR TITLE
Dest already exists

### DIFF
--- a/lib/delta-file.js
+++ b/lib/delta-file.js
@@ -44,7 +44,7 @@ export default class DeltaFile {
           res.body.pipe(writeStream);
           writeStream.on('close', () => resolve());
           writeStream.on('error', reject);
-      }));
+        }));
     } catch(e) {
       console.log(`Something went wrong while downloading file from ${this.downloadUrl}`);
       console.log(e);
@@ -77,7 +77,12 @@ export default class DeltaFile {
         }).format(new Date(this.created));
         const directory = path.join(DELTA_FILE_FOLDER, folderByDay);
         await fs.ensureDir(directory);
-        await fs.move(this.filePath, path.join(directory, this.fileName));
+        const pathExists = await fs.pathExists(path.join(directory, this.fileName));
+        if (!pathExists) {
+          await fs.move(this.filePath, path.join(directory, this.fileName));
+        } else {
+          await fs.remove(this.filePath);
+        }
       }
 
       return convertedChangeSets;

--- a/lib/dump-file.js
+++ b/lib/dump-file.js
@@ -14,6 +14,8 @@ import {
     SYNC_DATASET_SUBJECT,
     SYNC_FILES_PATH,
 } from '../config';
+import * as fetch from 'node-fetch';
+
 
 const BASEPATH = path.join(SYNC_FILES_PATH, DUMPFILE_FOLDER);
 fs.ensureDirSync(BASEPATH);
@@ -174,7 +176,7 @@ class DumpFile {
       };
     });
 
-    await dispatch({ mu, muAuthSudo }, { termObjects: triples });
+    await dispatch({ mu, muAuthSudo, fetch }, { termObjects: triples });
   }
 
   serializeN3Term(rdfTerm) {


### PR DESCRIPTION
If a file gets downloaded while the consumer get restarted for example, the consumer will get stuck when trying to move the new delta file where the old one, with the same name, has already been moved. This PR fixes it.