### PR TITLE
Improve failure of job.

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -2,7 +2,7 @@ import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeDateTime, sparqlEscapeString, sparqlEscapeUri, uuid } from 'mu';
 import { JOB_TYPE, JOB_URI_PREFIX,
          PREFIXES, STATUS_SCHEDULED,
-         STATUS_FAILED, TASK_TYPE } from './constants';
+         STATUS_FAILED, STATUS_SUCCESS, TASK_TYPE } from './constants';
 import { parseResult, updateStatus } from './utils';
 
 export async function createJob(jobsGraph,
@@ -153,10 +153,40 @@ export async function getJobs(jobOperationUri,
 export async function failJob( job ) {
   let jobObject = await loadJob(job);
 
-  for(const task of jobObject.tasks){
-    await updateStatus(task, STATUS_FAILED);
-  }
-  await updateStatus(jobObject.job, STATUS_FAILED);
+  const failQuery = `
+    ${PREFIXES}
+
+    DELETE {
+        GRAPH ?g {
+         ?job adms:status ?jobStatus.
+         ?task adms:status ?taskStatus.
+       }
+    }
+    INSERT {
+        GRAPH ?g {
+         ?job adms:status ${sparqlEscapeUri(STATUS_FAILED)}.
+         ?task adms:status ${sparqlEscapeUri(STATUS_FAILED)}.
+       }
+    }
+    WHERE {
+      VALUES ?job {
+        ${sparqlEscapeUri(job)}
+      }
+      GRAPH ?g {
+        ?job a ${sparqlEscapeUri(JOB_TYPE)};
+          adms:status ?jobStatus.
+
+        ?task a ${sparqlEscapeUri(TASK_TYPE)};
+          adms:status ?taskStatus;
+          dct:isPartOf ?job.
+
+       FILTER NOT EXISTS {
+         ?task adms:status ${sparqlEscapeUri(STATUS_SUCCESS)}.
+       }
+      }
+   }
+  `;
+  await update(failQuery);
 }
 
 export async function cleanupJob(job) {


### PR DESCRIPTION
Previously if a job was not finished it failed all tasks. Even if the task was a success. Since we use the last success task to calculate the next delta to consume; this might lead restart too many tasks being redone again.
By failing only the non success tasks; when we restart we restart right at where we left.

Note: this is another version compared with commit 7fbeec59e18c898cf16ffa85256248ec432ca6ec.
It might be faster; but also might be too heavy for mu-auth