### PR TITLE
update cron to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/lblod/delta-consumer#readme",
   "dependencies": {
     "@lblod/mu-auth-sudo": "0.6.1",
-    "cron": "^1.8.2",
+    "cron": "^3.1.7",
     "fs-extra": "^9.0.1",
     "lodash": "^4.17.21",
     "n3": "^1.11.1",


### PR DESCRIPTION
Changes to take into account:

Month & day-of-week indexing changes
Month Indexing: Changed from 0-11 to 1-12. So you need to increment all numeric months by 1.

Day-of-Week Indexing: Support added for 7 as Sunday.


So this should be a breaking release, these changes only affect from version 2 to version 3, but the bug I found was solved in 2.4.1 I considered it would be best to update to v3 to avoid future problems as the breaking changes are so small and easy to fix, but let me know if I should just release an update to 2.4.1