### PR TITLE
Bugfix/ensure one match per triple in graph pattern

### DIFF
--- a/lib/delta-sparql-mapping.js
+++ b/lib/delta-sparql-mapping.js
@@ -257,9 +257,9 @@ function filterAndBindQueries(queries, deltaTriple) {
   }
 
   // For every incoming delta/triple, we need to substitute the variables
-  // in the graph patterns from the mapping queries with the values from the triple.
+  // in the triple (graph) patterns from the mapping queries with the values from the triple.
   // One mapping query can result in multiple subsituted instantances of mapping queries,
-  // as the mapping query may contain multiple variables.
+  // as the mapping query may contain multiple triples (graph)patterns.
 
   const substitutedQueries = [];
   for(const query of queries) {

--- a/lib/delta-sparql-mapping.js
+++ b/lib/delta-sparql-mapping.js
@@ -255,29 +255,30 @@ function filterAndBindQueries(queries, deltaTriple) {
       ],
     };
   }
-  return queries.filter((parsedQuery) => {
-    let hasMatch = false; // Flag to track if any match is found
 
-    // The generated update queries have one graph pattern in one where clause
-    parsedQuery.updates.forEach((update) => {
-      // update.where.forEach((where) => {
-      //   where.patterns.forEach((pattern) => {
-      //     pattern.triples.forEach((queryPattern) => {
-      update.where[0].patterns[0].triples.forEach((queryPattern) => {
-        const matches = matchesPattern(queryPattern, deltaTriple);
-        if (matches) {
-          console.log(
-            `Match found for query: ${sparqlGenerator.stringify(parsedQuery)}`,
-          );
-          parsedQuery = bindVariable(parsedQuery, queryPattern, deltaTriple);
-          hasMatch = true; // Set flag to true if a match is found
-        }
-        //     });
-        //   });
-      });
-    });
-    return hasMatch; // Keep this parsedQuery only if a match was found
-  });
+  // For every incoming delta/triple, we need to substitute the variables
+  // in the graph patterns from the mapping queries with the values from the triple.
+  // One mapping query can result in multiple subsituted instantances of mapping queries,
+  // as the mapping query may contain multiple variables.
+
+  const substitutedQueries = [];
+  for(const query of queries) {
+    const update  = query.updates[0]; //TODO: add validation on hard assumption
+    const triples = update.where[0].patterns[0].triples; //TODO: add validation on hard assumption
+    for(const queryPattern of triples) {
+      const matches = matchesPattern(queryPattern, deltaTriple);
+      if (matches) {
+        console.log(
+          `Match found for query: ${sparqlGenerator.stringify(query)}`,
+        );
+        const clonedQuery = structuredClone(query);
+        const substitutedQuery = bindVariable(clonedQuery, queryPattern, deltaTriple);
+        substitutedQueries.push(substitutedQuery);
+      }
+    }
+  }
+
+  return substitutedQueries;
 }
 
 async function insertTripleInLandingZone(triple) {


### PR DESCRIPTION
Previously, all variables the triple graph patterns in a mapping query were substituted with
the (potentially) corresponding
`?s ?p ?o` in the delta. In the same mapping query.

This resulted in subsitutions like

```
DELETE { GRAPH <http://mu.semte.ch/graphs/public> { ?bestuursorgaan skos:prefLabel ?bestuursorgaanLabel. } }
WHERE {
  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid;
      org:classification ?classificatie.
    ?classificatie skos:prefLabel ?classificatieLabel.
    ?bestuurseenheid skos:prefLabel ?bestuurseenheidLabel.
    BIND(CONCAT(STR(?classificatieLabel), " ", STR(?bestuurseenheidLabel)) AS ?bestuursorgaanLabel)
  }
  VALUES ?classificatie {
    <http://data.lblod.info/id/besturenVanDeEredienst/670F7C771A60654C14CF2D16>
  }
  VALUES ?classificatieLabel {
    "2024-10-16-test-felix-21-10-2024"
  }
  VALUES ?bestuurseenheid {
    <http://data.lblod.info/id/besturenVanDeEredienst/670F7C771A60654C14CF2D16>
  }
  VALUES ?bestuurseenheidLabel {
    "2024-10-16-test-felix-21-10-2024"
}
}
```
Which can't work.
Now the same triple will result in multiple subsituted mapping
queries.
Like

```
DELETE { GRAPH <http://mu.semte.ch/graphs/public> { ?bestuursorgaan skos:prefLabel ?bestuursorgaanLabel. } }
WHERE {
  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid;
      org:classification ?classificatie.
    ?classificatie skos:prefLabel ?classificatieLabel.
    ?bestuurseenheid skos:prefLabel ?bestuurseenheidLabel.
    BIND(CONCAT(STR(?classificatieLabel), " ", STR(?bestuurseenheidLabel)) AS ?bestuursorgaanLabel)
  }
  VALUES ?bestuurseenheid {
    <http://data.lblod.info/id/besturenVanDeEredienst/670F7C771A60654C14CF2D16>
  }
  VALUES ?bestuurseenheidLabel {
    "2024-10-16-test-felix-21-10-2024"
}
}
```
and

```
DELETE { GRAPH <http://mu.semte.ch/graphs/public> { ?bestuursorgaan skos:prefLabel ?bestuursorgaanLabel. } }
WHERE {
  GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid;
      org:classification ?classificatie.
    ?classificatie skos:prefLabel ?classificatieLabel.
    ?bestuurseenheid skos:prefLabel ?bestuurseenheidLabel.
    BIND(CONCAT(STR(?classificatieLabel), " ", STR(?bestuurseenheidLabel)) AS ?bestuursorgaanLabel)
  }
  VALUES ?classificatie {
    <http://data.lblod.info/id/besturenVanDeEredienst/670F7C771A60654C14CF2D16>
  }
  VALUES ?classificatieLabel {
    "2024-10-16-test-felix-21-10-2024"
  }
}
```