### PR TITLE
Use also the `lang` attribute for language tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.0
+ - Fix another bug in handling language tags: use both `xml:lang` and `lang`. Thanks to @cecemel for pointing out the cause of the problems. This is a breaking change as it changes the way deltas (with language tags) are parsed and executed onto the triplestore. **If producer data can contain language tags, make sure to flush data and sync job data, before performing a re-sync.**
+   - see [#31](https://github.com/lblod/delta-consumer/pull/31)
 ## 0.0.27
  - Fix bug in handling `lang` strings not being according to `rdf/json`
    - see: [#30](https://github.com/lblod/delta-consumer/pull/30)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -66,11 +66,12 @@ export function parseResult(result) {
  */
 export function toTermObjectArray(triples) {
   const escape = function (rdfTerm) {
-    //TODO: there is still the case where the rdfTerm doesn't contain `xml:lang` but `lang`.
-    // This fix could potentially have a big impact, so I would postpone this for a major release.
-    // It seems that `xml:lang` is not according to the spec: https://www.w3.org/TR/rdf-json/
-    //   not to be confused with https://www.w3.org/TR/sparql11-results-json/
-    const { type, value, datatype, 'xml:lang': lang } = rdfTerm;
+    const { type, value, datatype } = rdfTerm;
+    // Might not be ideal: two ways of anotating language
+    //   xml:lang  conforms to https://www.w3.org/TR/sparql11-results-json/
+    //   lang      conforms to https://www.w3.org/TR/rdf-json/
+    // We look for both to capture all intentions.
+    const lang = rdfTerm['xml:lang'] || rdfTerm?.lang;
     if (type === 'uri') {
       return sparqlEscapeUri(value);
     } else if (type === 'literal' || type === 'typed-literal') {


### PR DESCRIPTION
(Related to **[DL-6286]** and subtasks)

Look for both the `xml:lang` and `lang` properties in the delta files for language attribution. These two properties are used by different standards, but mean the same thing.

This service would in many cases ignore a language tag, simply because the delta file was using a different specification. This causes triples to be missing important context or deletes failing to delete the correct triple or in some cases to delete the wrong triple.

**This could be a breaking change!**

We recommend flushing the sync jobs and restarting the whole sync. Even better: flush the sync jobs and delete the previously synchronised data before restarting the whole sync (initial sync job and remaining delta sync jobs).