### PR TITLE
Use relative file paths when importing `/config` files

### DIFF
--- a/triples-dispatching/index.js
+++ b/triples-dispatching/index.js
@@ -1,10 +1,10 @@
 import { ENABLE_CUSTOM_DISPATCH } from "../config";
 
-const initialSyncDispatching = tryLoadModule('/config/triples-dispatching/custom-dispatching/initial-sync-dispatching',
+const initialSyncDispatching = tryLoadModule('./../config/triples-dispatching/custom-dispatching/initial-sync-dispatching',
   './single-graph-dispatching/initial-sync-dispatching');
-const deltaSyncDispatching = tryLoadModule('/config/triples-dispatching/custom-dispatching/delta-sync-dispatching',
+const deltaSyncDispatching = tryLoadModule('./../config/triples-dispatching/custom-dispatching/delta-sync-dispatching',
   './single-graph-dispatching/delta-sync-dispatching');
-const deltaContextConfiguration = tryLoadModule('/config/triples-dispatching/custom-dispatching/delta-context-config',
+const deltaContextConfiguration = tryLoadModule('./../config/triples-dispatching/custom-dispatching/delta-context-config',
   './single-graph-dispatching/delta-context-config');
 
 function tryLoadModule(targetModulePath, fallbackModulePath) {


### PR DESCRIPTION
When absolute paths are used, the environment doesn't consider the files part of the module, and you can't use import statements in the mounted files.

As a bonus, all dependencies provided by the service will be available for the custom mounted files in /config.

See: DGS-472 (a tangent issue, where custom code couldn't import)