### PR TITLE
add accept encoding header

### DIFF
--- a/lib/delta-file.js
+++ b/lib/delta-file.js
@@ -50,7 +50,7 @@ export default class DeltaFile {
 
   async download() {
     try {
-      await fetcher(this.downloadUrl)
+      await fetcher(this.downloadUrl, { headers: { 'Accept-encoding': 'gzip,deflate'}})
         .then(res => new Promise((resolve, reject) => {
           const writeStream = fs.createWriteStream(this.filePath);
           res.body.pipe(writeStream);

--- a/lib/dump-file.js
+++ b/lib/dump-file.js
@@ -226,7 +226,8 @@ export async function getLatestDumpFile() {
       urlToCall,
       {
         headers: {
-          'Accept': 'application/vnd.api+json'
+          'Accept': 'application/vnd.api+json',
+          'Accept-encoding': 'deflate,gzip',
         }
       }
     );

--- a/pipelines/delta-sync.js
+++ b/pipelines/delta-sync.js
@@ -125,7 +125,8 @@ async function getSortedUnconsumedFiles(since) {
     console.log(`Fetching delta files with url: ${urlToCall}`);
     const response = await fetcher(urlToCall, {
       headers: {
-        'Accept': 'application/vnd.api+json'
+        'Accept': 'application/vnd.api+json',
+        'Accept-encoding': 'deflate,gzip',
       }
     });
     const json = await response.json();


### PR DESCRIPTION
our stack supports gzipping on the fly, so should be backwards compatible. in general quite the performance gain if you have larger files