### PR TITLE
Download file with progress

### DIFF
--- a/lib/dump-file.js
+++ b/lib/dump-file.js
@@ -1,7 +1,6 @@
 import * as muAuthSudo from '@lblod/mu-auth-sudo';
 import * as mu from 'mu';
 import fs from 'fs-extra';
-import readline from 'readline';
 import { Writable } from 'stream';
 import { sparqlEscapeString, sparqlEscapeUri } from 'mu';
 import { Parser, StreamParser } from 'n3';
@@ -24,6 +23,7 @@ import {
 } from '../config';
 import * as fetch from 'node-fetch';
 import { insertIntoLandingZoneGraph } from './delta-context';
+import { downloadFile } from './utils';
 
 const BASEPATH = path.join(SYNC_FILES_PATH, DUMPFILE_FOLDER);
 fs.ensureDirSync(BASEPATH);
@@ -46,13 +46,7 @@ class DumpFile {
 
   async download() {
     try {
-      await fetcher(this.downloadUrl)
-        .then(res => new Promise((resolve, reject) => {
-          const writeStream = fs.createWriteStream(this.filePath);
-          res.body.pipe(writeStream);
-          writeStream.on('close', () => resolve());
-          writeStream.on('error', reject);
-        }));
+      await downloadFile(this.downloadUrl, this.filePath);
     } catch (e) {
       console.log(`Something went wrong while downloading file from ${this.downloadUrl}`);
       console.log(e);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,8 @@ import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeDateTime, sparqlEscapeUri, sparqlEscapeString } from 'mu';
 import { PREFIXES } from './constants';
 import { Transform } from 'stream';
+import { pipeline } from 'stream/promises';
+import { createWriteStream } from 'fs';
 import fetcher from './fetcher';
 import DeltaFile from "./delta-file";
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,8 @@
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeDateTime, sparqlEscapeUri, sparqlEscapeString } from 'mu';
 import { PREFIXES } from './constants';
+import { Transform } from 'stream';
+import fetcher from './fetcher';
 import DeltaFile from "./delta-file";
 
 export async function updateStatus(subject, status) {
@@ -122,4 +124,27 @@ async function getDeltaFilesForTask( taskUri ) {
     ({ id, name, created }) =>
     new DeltaFile({id, attributes: { created: created.toISOString(), name }})
   );
+}
+
+export async function downloadFile(url, filePath) {
+    const res = await fetcher(url, {
+        headers: { 'Accept-encoding': 'gzip,deflate' },
+    });
+    let downloaded = 0;
+    const startTime = Date.now();
+    const progressStream = new Transform({
+        transform(chunk, _, callback) {
+            downloaded += chunk.length;
+            const elapsedSec = (Date.now() - startTime) / 1000;
+            const mb = downloaded / 1024 / 1024;
+            const mbPerSec = mb / elapsedSec;
+            console.log(
+                `Downloaded ${mb.toFixed(2)}mb at an avg speed of ${mbPerSec.toFixed(2)} mb/s`
+            );
+            this.push(chunk);
+            callback();
+        },
+    });
+    const fileStream = createWriteStream(filePath);
+    await pipeline(res.body, progressStream, fileStream);
 }


### PR DESCRIPTION
shows progress when downloading the dump file
Context: sometimes the dump file is so large and it feels nothing is happening in the background, adding some progress logs helps making sure the service is actually working.